### PR TITLE
Allow False in ScopusAbstract download

### DIFF
--- a/scopus/scopus_author.py
+++ b/scopus/scopus_author.py
@@ -427,11 +427,12 @@ class ScopusAuthor(object):
 
         return '\n'.join(s)
 
-    def author_impact_factor(self, year=2014):
+    def author_impact_factor(self, year=2014, refresh=True):
         """Get author_impact_factor.
+
         Returns (ncites, npapers, aif)
         """
-        scopus_abstracts = [ScopusAbstract(eid, refresh=True)
+        scopus_abstracts = [ScopusAbstract(eid, refresh=refresh)
                             for eid in self.get_document_eids()
                             if ScopusAbstract(eid).aggregationType == 'Journal']
 
@@ -439,7 +440,6 @@ class ScopusAuthor(object):
         years = [int(ab.coverDate.split('-')[0]) for ab in scopus_abstracts]
 
         data = zip(years, cites, scopus_abstracts)
-        from operator import itemgetter
         data = sorted(data, key=itemgetter(1), reverse=True)
 
         # now get aif papers for year-1 and year-2


### PR DESCRIPTION
I was wondering why retrieving the `author_impact_factor` took so long. One reason is that the abstracts are downloaded again. So I implemented an optional boolean that steers this behaviour.

If you like it I am happy to implement this all over the file.