### PR TITLE
Use Scopus identifier from xml

### DIFF
--- a/scopus/scopus_author.py
+++ b/scopus/scopus_author.py
@@ -21,7 +21,6 @@ if not os.path.exists(SCOPUS_AUTHOR_DIR):
 
 class ScopusAuthor(object):
     """Class to represent a Scopus Author query by the scopus-id."""
-
     @property
     def author_id(self):
         """The scopus id for the author."""
@@ -112,7 +111,6 @@ class ScopusAuthor(object):
         if isinstance(author_id, int):
             author_id = str(author_id)
 
-        self._author_id = author_id
         self.level = level
 
         qfile = os.path.join(SCOPUS_AUTHOR_DIR, author_id)
@@ -148,6 +146,10 @@ class ScopusAuthor(object):
         ndocuments = get_encoded_text(self.results,
                                       'coredata/document-count')
         self._ndocuments = int(ndocuments) if ndocuments is not None else 0
+
+        _author_id = get_encoded_text(self.results, 'coredata/dc:identifier')
+        _author_id = _author_id.split(":")[-1]
+        self._author_id = _author_id
 
         ncitations = get_encoded_text(self.results,
                                       'coredata/citation-count')


### PR DESCRIPTION
Sometimes the Scopus ID of an author is not the same as the ID used for the search.  In this case the ID has been redirected to the new profile.  I happens quite frequent due to merges.  Hence I propose to use the ID provided by Scopus.  This allows searching for duplicate entries.