### PR TITLE
Fix bug with too many classifications tags in xml

### DIFF
--- a/scopus/scopus_author.py
+++ b/scopus/scopus_author.py
@@ -21,6 +21,7 @@ if not os.path.exists(SCOPUS_AUTHOR_DIR):
 
 class ScopusAuthor(object):
     """Class to represent a Scopus Author query by the scopus-id."""
+
     @property
     def author_id(self):
         """The scopus id for the author."""
@@ -111,6 +112,7 @@ class ScopusAuthor(object):
         if isinstance(author_id, int):
             author_id = str(author_id)
 
+        self._author_id = author_id
         self.level = level
 
         qfile = os.path.join(SCOPUS_AUTHOR_DIR, author_id)
@@ -146,10 +148,6 @@ class ScopusAuthor(object):
         ndocuments = get_encoded_text(self.results,
                                       'coredata/document-count')
         self._ndocuments = int(ndocuments) if ndocuments is not None else 0
-
-        _author_id = get_encoded_text(self.results, 'coredata/dc:identifier')
-        _author_id = _author_id.split(":")[-1]
-        self._author_id = _author_id
 
         ncitations = get_encoded_text(self.results,
                                       'coredata/citation-count')
@@ -196,7 +194,7 @@ class ScopusAuthor(object):
 
         classifications = self.results.findall('author-profile/'
                                                'classificationgroup/'
-                                               'classifications/'
+                                               'classifications[@type="ASJC"]/'
                                                'classification')
         # {code: frequency}
         c = {int(cls.text): int(cls.attrib['frequency'])

--- a/scopus/scopus_author.py
+++ b/scopus/scopus_author.py
@@ -21,7 +21,6 @@ if not os.path.exists(SCOPUS_AUTHOR_DIR):
 
 class ScopusAuthor(object):
     """Class to represent a Scopus Author query by the scopus-id."""
-
     @property
     def author_id(self):
         """The scopus id for the author."""
@@ -112,7 +111,6 @@ class ScopusAuthor(object):
         if isinstance(author_id, int):
             author_id = str(author_id)
 
-        self._author_id = author_id
         self.level = level
 
         qfile = os.path.join(SCOPUS_AUTHOR_DIR, author_id)
@@ -148,6 +146,10 @@ class ScopusAuthor(object):
         ndocuments = get_encoded_text(self.results,
                                       'coredata/document-count')
         self._ndocuments = int(ndocuments) if ndocuments is not None else 0
+
+        _author_id = get_encoded_text(self.results, 'coredata/dc:identifier')
+        _author_id = _author_id.split(":")[-1]
+        self._author_id = _author_id
 
         ncitations = get_encoded_text(self.results,
                                       'coredata/citation-count')


### PR DESCRIPTION
In rare instances (i.e. author profile 34769659200) there is more than one `classifications` tag within `classificationgroup`:

```
<classificationgroup xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 <classifications type="ASJC">
  <classification frequency="1">2002</classification>
 </classifications>
 <classifications type="SUBJECT">
  <classification frequency="1">Business, Economics and Management Science</classification>
 </classifications>
</classificationgroup> 
```

This caused the ScopusAuthor class `__init__` to break in lines 197-200.  My fix only looks for `classifications` tags with attribute `type="ASJC"` only.