### PR TITLE
Outsource download facility to __init.py__

### DIFF
--- a/scopus/__init__.py
+++ b/scopus/__init__.py
@@ -47,6 +47,11 @@ def get_content(qfile, url, refresh, header, params=None, ):
         and accepted values see e.g.
         https://api.elsevier.com/documentation/AuthorRetrievalAPI.wadl
 
+    Raises
+    ------
+    HTTPError
+        If the status of the response is not ok.
+
     Returns
     -------
     content : str
@@ -57,6 +62,7 @@ def get_content(qfile, url, refresh, header, params=None, ):
             content = f.read()
     else:
         resp = requests.get(url, headers=header, params=params)
+        resp.raise_for_status()  # Raise status code if necessary
         content = resp.text.encode('utf-8')
         with open(qfile, 'wb') as f:
             f.write(content)

--- a/scopus/__init__.py
+++ b/scopus/__init__.py
@@ -1,4 +1,5 @@
 import os
+import requests
 import sys
 
 SCOPUS_API_FILE = os.path.expanduser("~/.scopus/my_scopus.py")
@@ -20,6 +21,46 @@ ns = {'dtd': 'http://www.elsevier.com/xml/svapi/abstract/dtd',
       'dc': 'http://purl.org/dc/elements/1.1/',
       'atom': 'http://www.w3.org/2005/Atom',
       'opensearch': 'http://a9.com/-/spec/opensearch/1.1/'}
+
+
+def get_content(qfile, url, refresh, header, params=None, ):
+    """Helper function to read file content, download and save if necessary.
+
+    Parameters
+    ----------
+    qfile : string
+        The name of the file to be created.
+
+    url : string
+        The URL to be parsed.
+
+    refresh : bool
+        Whether the file content should be refreshed if it exists.
+
+    header : string
+        Dictionary containing header parameters.  For required keys
+        and accepted values see e.g.
+        https://api.elsevier.com/documentation/AuthorRetrievalAPI.wadl
+
+    params : dict (optional)
+        Dictionary containing query parameters.  For required keys
+        and accepted values see e.g.
+        https://api.elsevier.com/documentation/AuthorRetrievalAPI.wadl
+
+    Returns
+    -------
+    content : str
+        The content of the file.
+    """
+    if os.path.exists(qfile) and not refresh:
+        with open(qfile, 'rb') as f:
+            content = f.read()
+    else:
+        resp = requests.get(url, headers=header, params=params)
+        content = resp.text.encode('utf-8')
+        with open(qfile, 'wb') as f:
+            f.write(content)
+    return content
 
 
 def get_encoded_text(container, xpath):

--- a/scopus/scopus_api.py
+++ b/scopus/scopus_api.py
@@ -1,5 +1,4 @@
-from . import ns, get_encoded_text, MY_API_KEY
-import requests
+from . import ns, get_content, get_encoded_text, MY_API_KEY
 import xml.etree.ElementTree as ET
 import os
 import sys
@@ -152,29 +151,11 @@ class ScopusAbstract(object):
             raise ValueError('view parameter must be one of ' +\
                              ', '.join(allowed_views))
 
-        fEID = os.path.join(SCOPUS_XML_DIR, EID)
-        self.file = fEID
-
-        if os.path.exists(fEID) and not refresh:
-            with open(fEID) as f:
-                text = f.read()
-                self.xml = text
-                results = ET.fromstring(text)
-        else:
-            url = "http://api.elsevier.com/content/abstract/eid/{}".format(EID)
-
-            resp = requests.get(url,
-                                headers={'Accept': 'application/xml',
-                                         'X-ELS-APIKey': MY_API_KEY},
-                                params={'view': view})
-            self.xml = resp.text
-            with open(fEID, 'w') as f:
-                if sys.version_info[0] == 3:
-                    f.write(self.xml)
-                else:
-                    f.write(self.xml.encode('utf-8'))
-
-            results = ET.fromstring(resp.text.encode('utf-8'))
+        qfile = os.path.join(SCOPUS_XML_DIR, EID)
+        url = "http://api.elsevier.com/content/abstract/eid/{}".format(EID)
+        header = {'Accept': 'application/xml', 'X-ELS-APIKey': MY_API_KEY}
+        params = {'view': view}
+        results = ET.fromstring(get_content(qfile, url, refresh, header, params))
 
         coredata = results.find('dtd:coredata', ns)
         authors = results.find('dtd:authors', ns)


### PR DESCRIPTION
I wasn't happy with the file IO operation (get file content if exists, download if necessary or desired) being hard-coded three times, although very similar.  So I outsourced it to a helper function named `get_content()` which is now in `__init.py__`.  This enables us to tweak the function only once.

It comes with complete description of all parameters.  There is also a [`.raise_for_status()`](http://docs.python-requests.org/en/master/api/?highlight=raise_for_status), which is a function belonging to `requests`.  It raises an error if the server sends an error, i.e. when the quota is exceeded (which was the problem of #16).

I checked it oon python2.7 and python3 - everything works, even though there is a one-size-fits-all versions solution.  This is achieved by writing in binary mode.

It's not optimal that we have to provide the url, the header and the parameters even if we do not need them (namely when `refresh=False` and the file exists).  But I think that is a minor cost for having everything in one place and to adhere to DRY.  Or what do you think?

Later on the function should be moved into a helper script or a class of helper scripts in a new folder `utils`.